### PR TITLE
Update samples' Readme docs

### DIFF
--- a/functions/OpenFuncAsync/pubsub/subscriber/subscriber.go
+++ b/functions/OpenFuncAsync/pubsub/subscriber/subscriber.go
@@ -1,4 +1,4 @@
-package main
+package subscriber
 
 import (
 	ofctx "github.com/OpenFunction/functions-framework-go/openfunction-context"

--- a/functions/hello-world-dotnet/README.md
+++ b/functions/hello-world-dotnet/README.md
@@ -22,8 +22,8 @@ spec:
       GOOGLE_FUNCTION_TARGET: "helloworld"
       GOOGLE_FUNCTION_SIGNATURE_TYPE: "http"
     srcRepo:
-      url: "https://github.com/OpenFunction/function-samples.git"
-      sourceSubPath: "hello-world-dotnet"
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/hello-world-dotnet"
     registry:
       url: "https://index.docker.io/v1/"
       account:

--- a/functions/hello-world-go/README.md
+++ b/functions/hello-world-go/README.md
@@ -22,8 +22,8 @@ spec:
       GOOGLE_FUNCTION_TARGET: "HelloWorld"
       GOOGLE_FUNCTION_SIGNATURE_TYPE: "http"
     srcRepo:
-      url: "https://github.com/OpenFunction/function-samples.git"
-      sourceSubPath: "hello-world-go"
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/hello-world-go"
     registry:
       url: "https://index.docker.io/v1/"
       account:

--- a/functions/hello-world-java/README.md
+++ b/functions/hello-world-java/README.md
@@ -22,8 +22,8 @@ spec:
       GOOGLE_FUNCTION_TARGET: "com.openfunction.HelloWorld"
       GOOGLE_FUNCTION_SIGNATURE_TYPE: "http"
     srcRepo:
-      url: "https://github.com/OpenFunction/function-samples.git"
-      sourceSubPath: "hello-world-java"
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/hello-world-java"
     registry:
       url: "https://index.docker.io/v1/"
       account:

--- a/functions/hello-world-node/README.md
+++ b/functions/hello-world-node/README.md
@@ -22,8 +22,8 @@ spec:
       GOOGLE_FUNCTION_TARGET: "helloWorld"
       GOOGLE_FUNCTION_SIGNATURE_TYPE: "http"
     srcRepo:
-      url: "https://github.com/OpenFunction/function-samples.git"
-      sourceSubPath: "hello-world-node"
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/hello-world-node"
     registry:
       url: "https://index.docker.io/v1/"
       account:

--- a/functions/hello-world-python/README.md
+++ b/functions/hello-world-python/README.md
@@ -23,8 +23,8 @@ spec:
       GOOGLE_FUNCTION_SIGNATURE_TYPE: "http"
       # GOOGLE_FUNCTION_SOURCE: "main.py" # for python function
     srcRepo:
-      url: "https://github.com/OpenFunction/function-samples.git"
-      sourceSubPath: "hello-world-python"
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/hello-world-python"
     registry:
       url: "https://index.docker.io/v1/"
       account:


### PR DESCRIPTION
1. Update the `srcRepo` informations in samples' readme docs. Rename `function-samples` to `samples`.
2. Fix OpenFuncAsync sample's package name.

Signed-off-by: laminar <fangtian@kubesphere.io>