### PR TITLE
fix  FUNC_CONTEXT  value 

### DIFF
--- a/latest/functions-framework/golang/OpenFuncAsync/pubsub/README.md
+++ b/latest/functions-framework/golang/OpenFuncAsync/pubsub/README.md
@@ -69,7 +69,7 @@ You also need a definition of producer.
 Create an environment variable `FUNC_CONTEXT` and assign the above context to it.
 
 ```shell
-export FUNC_CONTEXT='{"name":"producer","version":"v1","requestID":"a0f2ad8d-5062-4812-91e9-95416489fb01","port":"60012","inputs":{},"outputs":{"msg":{"uri":"my_topic","component":"msg","type":"pubsub"}},"runtime":"OpenFuncAsync"}'
+export FUNC_CONTEXT='{"name":"producer","version":"v1","requestID":"a0f2ad8d-5062-4812-91e9-95416489fb01","port":"60012","inputs":{},"outputs":{"pub":{"uri":"my_topic","component":"msg","type":"pubsub"}},"runtime":"OpenFuncAsync"}'
 ```
 
 Start the service with another terminal to publish message.

--- a/v0.4.0/functions-framework/golang/OpenFuncAsync/pubsub/README.md
+++ b/v0.4.0/functions-framework/golang/OpenFuncAsync/pubsub/README.md
@@ -69,7 +69,7 @@ You also need a definition of producer.
 Create an environment variable `FUNC_CONTEXT` and assign the above context to it.
 
 ```shell
-export FUNC_CONTEXT='{"name":"producer","version":"v1","requestID":"a0f2ad8d-5062-4812-91e9-95416489fb01","port":"60012","inputs":{},"outputs":{"msg":{"uri":"my_topic","component":"msg","type":"pubsub"}},"runtime":"OpenFuncAsync"}'
+export FUNC_CONTEXT='{"name":"producer","version":"v1","requestID":"a0f2ad8d-5062-4812-91e9-95416489fb01","port":"60012","inputs":{},"outputs":{"pub":{"uri":"my_topic","component":"msg","type":"pubsub"}},"runtime":"OpenFuncAsync"}'
 ```
 
 Start the service with another terminal to publish message.


### PR DESCRIPTION
in Producer ,The value of the `ouputs` field in the FUNC_CONTEXT variable should be `pub` instead of `msg`
because in `producer.go`  ,the  value of outputName is `put `,  Otherwise it will report an error `fmt.Errorf("output %s not found", outputName)`
```go
outputName       = getEnvVar("OUTPUT_NAME", "pub")
...
func getEnvVar(key, fallbackValue string) string {
	if val, ok := os.LookupEnv(key); ok {
		return strings.TrimSpace(val)
	}
	return fallbackValue
}
...
if _, err := ctx.Send(outputName, d); err != nil {
				logger.Printf("send error, %v", err)
				resultCh <- false
}
```