### PR TITLE
add the goproxy to avoid network problem

### DIFF
--- a/latest/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
+++ b/latest/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
@@ -11,6 +11,7 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "LogsHandler"
+      FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "latest/functions/OpenFuncAsync/logs-handler-function/"

--- a/latest/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
+++ b/latest/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
@@ -11,7 +11,8 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "LogsHandler"
-      FUNC_GOPROXY: "https://goproxy.cn"
+      # Use FUNC_GOPROXY to set the goproxy
+      #FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "latest/functions/OpenFuncAsync/logs-handler-function/"

--- a/latest/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
+++ b/latest/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
@@ -11,6 +11,7 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Producer"
+      FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "latest/functions/OpenFuncAsync/pubsub/producer/"

--- a/latest/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
+++ b/latest/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
@@ -11,7 +11,8 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Producer"
-      FUNC_GOPROXY: "https://goproxy.cn"
+      # Use FUNC_GOPROXY to set the goproxy
+      #FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "latest/functions/OpenFuncAsync/pubsub/producer/"

--- a/latest/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
+++ b/latest/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
@@ -11,6 +11,7 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Subscriber"
+      FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "latest/functions/OpenFuncAsync/pubsub/subscriber"

--- a/latest/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
+++ b/latest/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
@@ -11,7 +11,8 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Subscriber"
-      FUNC_GOPROXY: "https://goproxy.cn"
+      # Use FUNC_GOPROXY to set the goproxy
+      #FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "latest/functions/OpenFuncAsync/pubsub/subscriber"

--- a/v0.4.0/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
+++ b/v0.4.0/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
@@ -11,6 +11,7 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "LogsHandler"
+      FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "v0.4.0/functions/OpenFuncAsync/logs-handler-function/"

--- a/v0.4.0/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
+++ b/v0.4.0/functions/OpenFuncAsync/logs-handler-function/logs-handler-function.yaml
@@ -11,7 +11,8 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "LogsHandler"
-      FUNC_GOPROXY: "https://goproxy.cn"
+      # Use FUNC_GOPROXY to set the goproxy
+      #FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "v0.4.0/functions/OpenFuncAsync/logs-handler-function/"

--- a/v0.4.0/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
+++ b/v0.4.0/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
@@ -11,6 +11,7 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Producer"
+      FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "v0.4.0/functions/OpenFuncAsync/pubsub/producer/"

--- a/v0.4.0/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
+++ b/v0.4.0/functions/OpenFuncAsync/pubsub/producer/function-producer.yaml
@@ -11,7 +11,8 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Producer"
-      FUNC_GOPROXY: "https://goproxy.cn"
+      # Use FUNC_GOPROXY to set the goproxy
+      #FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "v0.4.0/functions/OpenFuncAsync/pubsub/producer/"

--- a/v0.4.0/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
+++ b/v0.4.0/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
@@ -11,6 +11,7 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Subscriber"
+      FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "v0.4.0/functions/OpenFuncAsync/pubsub/subscriber"

--- a/v0.4.0/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
+++ b/v0.4.0/functions/OpenFuncAsync/pubsub/subscriber/function-subscriber.yaml
@@ -11,7 +11,8 @@ spec:
     builder: openfunctiondev/go115-builder:v0.3.0
     env:
       FUNC_NAME: "Subscriber"
-      FUNC_GOPROXY: "https://goproxy.cn"
+      # Use FUNC_GOPROXY to set the goproxy
+      #FUNC_GOPROXY: "https://goproxy.cn"
     srcRepo:
       url: "https://github.com/OpenFunction/samples.git"
       sourceSubPath: "v0.4.0/functions/OpenFuncAsync/pubsub/subscriber"


### PR DESCRIPTION
Although everyone knows that in the case of limited access to Google resources, you can add goproxy parameters to avoid errors, but in order to avoid modifying files after each clone, this pr is mentioned.