### PR TITLE
Add "markupsafe==2.0.1" as a requirement for python.

### DIFF
--- a/functions/Knative/hello-world-python/requirements.txt
+++ b/functions/Knative/hello-world-python/requirements.txt
@@ -1,1 +1,2 @@
 functions-framework==1.4.3
+markupsafe==2.0.1


### PR DESCRIPTION
Signed-off-by: laminar <fangtian@kubesphere.io>