### PR TITLE
add path-parameters-function go example

### DIFF
--- a/functions/knative/path-parameters-function-go/README.md
+++ b/functions/knative/path-parameters-function-go/README.md
@@ -11,7 +11,7 @@ You can refer to the [Installation Guide](https://github.com/OpenFunction/OpenFu
 Build the function locally
 
 ```sh
-pack build sample-go-path-params-func --builder openfunction/builder-go:v2.3.0-1.16 --env FUNC_NAME="pathParametersFunction"  --env FUNC_CLEAR_SOURCE=true
+pack build sample-go-path-params-func --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="pathParametersFunction"  --env FUNC_CLEAR_SOURCE=true
 ```
 
 Run the function
@@ -26,7 +26,7 @@ Send a request
 
 # http
 curl -X POST "http://localhost:8080/hello/openfunction"
-# {"hello":"openfunction"}% 
+# {"hello":"openfunction"}%
 
 # cloudevent
 curl -X POST "http://localhost:8080/foo/openfunction" \
@@ -39,7 +39,7 @@ curl -X POST "http://localhost:8080/foo/openfunction" \
 # http
 curl -X POST "http://localhost:8080/bar/openfunction" \
   -d 'hello'
-# {"hello":"openfunction"}%  
+# {"hello":"openfunction"}%
 
 # Structured CloudEvent
 curl -X POST "http://localhost:8080/bar/openfunction" \
@@ -103,10 +103,39 @@ You can create this secret by editing the ``REGISTRY_SERVER``, ``REGISTRY_USER``
    kubectl get functions.core.openfunction.io
    
    NAME              BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         URL                                                        AGE
-   function-sample   Succeeded    Running        builder-jgnzp   serving-gsx8g   http://openfunction.io/modelmesh-serving/function-sample   56s
+   function-sample   Succeeded    Running        builder-jgnzp   serving-gsx8g   http://function-sample.default.svc.cluster.local/          56s
     ```
-   
-   Trigger the function via the access address provided by the Knative Services:
+
+   The `Function.status.addresses` field provides various methods for accessing functions.
+   Get `Function` addresses by running following command:
+   ```shell
+   kubectl get function function-sample -o=jsonpath='{.status.addresses}'
+   ```
+   You will get the following address:
+   ```json
+   [{"type":"External","value":"http://function-sample.default.ofn.io/"},
+   {"type":"Internal","value":"http://function-sample.default.svc.cluster.local/"}]
+   ```
+
+   > You can use the following command to create a pod in the cluster and access the function from the pod:
+   >
+   > ```shell
+   > kubectl run curl --image=radial/busyboxplus:curl -i --tty
+   > ```
+   Access functions by the internal address:
+   ```shell
+   [ root@curl:/ ]$ curl http://function-sample.default.svc.cluster.local/hello/openfunction
+   {"hello":"openfunction"}%
+   ```
+
+   Access functions by the external address:
+   > To access the function via the Address of type `External` in `Funtion.status`, you should configure local domain first, see [Configure Local Domain](https://openfunction.dev/docs/concepts/networking/local-domain).
+   ```shell
+   [ root@curl:/ ]$ curl http://function-sample.default.ofn.io/hello/openfunction
+   {"hello":"openfunction"}%
+   ```
+
+   There is also an alternative way to trigger the function via the access address provided by the Knative Services:
 
     ```shell
     kubectl get ksvc

--- a/functions/knative/path-parameters-function-go/README.md
+++ b/functions/knative/path-parameters-function-go/README.md
@@ -1,0 +1,144 @@
+# Path Parameters Function Go
+
+## Prerequisites
+
+### OpenFunction
+
+You can refer to the [Installation Guide](https://github.com/OpenFunction/OpenFunction#install-openfunction) to setup OpenFunction.
+
+## Run it locally
+
+Build the function locally
+
+```sh
+pack build sample-go-path-params-func --builder openfunction/builder-go:v2.3.0-1.16 --env FUNC_NAME="pathParametersFunction"  --env FUNC_CLEAR_SOURCE=true
+```
+
+Run the function
+
+```sh
+docker compose up
+```
+
+Send a request
+
+```sh
+
+# http
+curl -X POST "http://localhost:8080/hello/openfunction"
+# {"hello":"openfunction"}% 
+
+# cloudevent
+curl -X POST "http://localhost:8080/foo/openfunction" \
+   -H "Content-Type: application/cloudevents+json" \
+   -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}'
+# in docker compose terminal:
+# cloudevent - Data: {"{\"data\":\"hello\"}":"openfunction"}
+
+
+# http
+curl -X POST "http://localhost:8080/bar/openfunction" \
+  -d 'hello'
+# {"hello":"openfunction"}%  
+
+# Structured CloudEvent
+curl -X POST "http://localhost:8080/bar/openfunction" \
+   -H "Content-Type: application/cloudevents+json" \
+   -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}'
+# {"{\"data\":\"hello\"}":"openfunction"}%
+
+# Binary CloudEvent
+curl "http://localhost:8080/bar/openfunction" \
+  -X POST \
+  -H "Ce-Specversion: 1.0" \
+  -H "Ce-Type: dev.knative.samples.helloworld" \
+  -H "Ce-Source: dev.knative.samples/helloworldsource" \
+  -H "Ce-Subject: 123" \
+  -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" \
+  -H "Content-Type: application/json" \
+  -d '{"data":"hello"}'
+# {"{\"data\":\"hello\"}":"openfunction"}%
+```
+
+
+## Deployment
+
+1. Create secret
+
+Generate a secret to access your container registry, such as one on [Docker Hub](https://hub.docker.com/) or [Quay.io](https://quay.io/).
+You can create this secret by editing the ``REGISTRY_SERVER``, ``REGISTRY_USER`` and ``REGISTRY_PASSWORD`` fields in following command, and then run it.
+
+  ```bash
+  REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user> REGISTRY_PASSWORD=<your_registry_password>
+  kubectl create secret docker-registry push-secret \
+      --docker-server=$REGISTRY_SERVER \
+      --docker-username=$REGISTRY_USER \
+      --docker-password=$REGISTRY_PASSWORD
+  ```
+
+2. Create function
+
+   For sample function below, modify the ``spec.image`` field in ``function-sample.yaml`` to your own container registry address:
+
+    ```yaml
+    apiVersion: core.openfunction.io/v1beta1
+    kind: Function
+    metadata:
+      name: function-sample
+    spec:
+      image: "<your registry name>/sample-go-path-params-func:latest"
+    ```
+
+   Use the following command to create this Function:
+
+    ```shell
+    kubectl apply -f function-sample.yaml
+    ```
+
+3. Access function
+
+   You can observe the process of a function with the following command:
+
+    ```shell
+   kubectl get functions.core.openfunction.io
+   
+   NAME              BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         URL                                                        AGE
+   function-sample   Succeeded    Running        builder-jgnzp   serving-gsx8g   http://openfunction.io/modelmesh-serving/function-sample   56s
+    ```
+   
+   Trigger the function via the access address provided by the Knative Services:
+
+    ```shell
+    kubectl get ksvc
+     
+    NAME                       URL                                                            LATESTCREATED                   LATESTREADY                     READY   REASON
+    serving-gsx8g-ksvc-6fv9l   http://serving-gsx8g-ksvc-6fv9l.default.<external-ip>.sslip.io   serving-gsx8g-ksvc-6fv9l-v100   serving-gsx8g-ksvc-6fv9l-v100   True
+    ```
+   
+   Or get the service address directly with the following command:
+   
+   > where` <external-ip> `indicates the external address of your gateway service.
+   >
+   > You can do a simple configuration to use the node ip as the `<external-ip>` as follows  (Assuming you are using Kourier as network layer of Knative). Where `1.2.3.4` can be replaced by your node ip.
+   >
+   > ```shell
+    > kubectl patch svc -n kourier-system kourier \
+    >   -p '{"spec": {"type": "LoadBalancer", "externalIPs": ["1.2.3.4"]}}'
+    > 
+    > kubectl patch configmap/config-domain -n knative-serving \
+    >   --type merge --patch '{"data":{"1.2.3.4.sslip.io":""}}'
+    > ```
+   
+    ```shell
+    kubectl get ksvc serving-gsx8g-ksvc-6fv9l -o jsonpath={.status.url}
+     
+    http://serving-gsx8g-ksvc-6fv9l.default.<external-ip>.sslip.io
+    ```
+   
+   Access the above service address via commands such as ``curl``:
+   
+    ```shell
+    curl http://serving-gsx8g-ksvc-6fv9l.default.<external-ip>.sslip.io/hello/openfunction
+     
+    {"hello":"openfunction"}% 
+    ```

--- a/functions/knative/path-parameters-function-go/docker-compose.yaml
+++ b/functions/knative/path-parameters-function-go/docker-compose.yaml
@@ -1,0 +1,43 @@
+# https://github.com/dapr/samples/tree/master/hello-docker-compose
+version: '3'
+services:
+  ############################
+  # myfunction + Dapr sidecar
+  ############################
+  myfunction:
+    image: sample-go-path-params-func
+    ports:
+      - "50001:50001" # Dapr instances communicate over gRPC so we need to expose the gRPC port
+      - "8080:8080"
+    environment:
+      FUNC_CONTEXT: "{\"name\":\"pathParametersFunction\",\"version\":\"v1.0.0\",\"port\":\"8080\",\"runtime\":\"Knative\"}"
+      CONTEXT_MODE: "self-host"
+    depends_on:
+      - placement
+    networks:
+      - hello-dapr
+  myfunction-dapr:
+    image: "daprio/daprd:edge"
+    command: [
+      "./daprd",
+     "-app-id", "pathParametersFunction",
+     "-app-port", "3000",
+     "-dapr-grpc-port", "50001",
+     "-placement-host-address", "placement:50006" # Dapr's placement service can be reach via the docker DNS entry
+     ]
+    depends_on:
+      - myfunction
+    network_mode: "service:myfunction" # Attach the myfunction-dapr service to the myfunction network namespace
+  ############################
+  # Dapr placement service
+  ############################
+  placement:
+    image: "daprio/dapr"
+    command: ["./placement", "-port", "50006"]
+    ports:
+      - "50006:50006"
+    networks:
+      - hello-dapr
+
+networks:
+    hello-dapr:

--- a/functions/knative/path-parameters-function-go/function-sample.yaml
+++ b/functions/knative/path-parameters-function-go/function-sample.yaml
@@ -9,7 +9,7 @@ spec:
     name: push-secret
   port: 8080 # default to 8080
   build:
-    builder: openfunction/builder-go:latest
+    builder: openfunction/builder-go:v2.4.0-1.17
     env:
       FUNC_NAME: "pathParametersFunction"
       FUNC_CLEAR_SOURCE: "true"

--- a/functions/knative/path-parameters-function-go/function-sample.yaml
+++ b/functions/knative/path-parameters-function-go/function-sample.yaml
@@ -1,0 +1,36 @@
+apiVersion: core.openfunction.io/v1beta1
+kind: Function
+metadata:
+  name: function-sample
+spec:
+  version: "v2.0.0"
+  image: "<image-registry>/sample-go-path-params-func:v1"
+  imageCredentials:
+    name: push-secret
+  port: 8080 # default to 8080
+  build:
+    builder: openfunction/builder-go:latest
+    env:
+      FUNC_NAME: "pathParametersFunction"
+      FUNC_CLEAR_SOURCE: "true"
+    srcRepo:
+      url: "https://github.com/OpenFunction/samples.git"
+      sourceSubPath: "functions/knative/path-parameters-function-go"
+      revision: "main"
+  serving:
+    template:
+      containers:
+        - name: function
+          imagePullPolicy: Always
+    runtime: "knative"
+    annotations:
+      # to enable dapr manually
+      # Dapr annotations: https://docs.dapr.io/reference/arguments-annotations-overview/
+      dapr.io/enabled: "true"
+      dapr.io/app-id: "function-sample-default"
+      dapr.io/app-port: "8080" # must equal to function port
+      dapr.io/dapr-grpc-port: "50001"
+      dapr.io/log-as-json: "true"
+      dapr.io/app-protocol: "grpc"
+      dapr.io/enable-metrics: "true"
+      dapr.io/metrics-port: "19090"

--- a/functions/knative/path-parameters-function-go/go.mod
+++ b/functions/knative/path-parameters-function-go/go.mod
@@ -1,0 +1,5 @@
+module example.com/hello
+
+go 1.16
+
+require github.com/OpenFunction/functions-framework-go v0.3.1-0.20220711114629-d397ef158649

--- a/functions/knative/path-parameters-function-go/go.mod
+++ b/functions/knative/path-parameters-function-go/go.mod
@@ -1,5 +1,5 @@
 module example.com/hello
 
-go 1.16
+go 1.17
 
-require github.com/OpenFunction/functions-framework-go v0.3.1-0.20220711114629-d397ef158649
+require github.com/OpenFunction/functions-framework-go v0.4.0

--- a/functions/knative/path-parameters-function-go/http.go
+++ b/functions/knative/path-parameters-function-go/http.go
@@ -1,0 +1,57 @@
+package hello
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	ofctx "github.com/OpenFunction/functions-framework-go/context"
+	"github.com/OpenFunction/functions-framework-go/functions"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	functions.HTTP("Hello", hello,
+		functions.WithFunctionPath("/hello/{name}"),
+		functions.WithFunctionMethods("GET", "POST"),
+	)
+
+	functions.CloudEvent("Foo", foo,
+		functions.WithFunctionPath("/foo/{name}"),
+	)
+
+	functions.OpenFunction("Bar", bar,
+		functions.WithFunctionPath("/bar/{name}"),
+		functions.WithFunctionMethods("GET", "POST"),
+	)
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	vars := ofctx.VarsFromCtx(r.Context())
+	response := map[string]string{
+		"hello": vars["name"],
+	}
+	responseBytes, _ := json.Marshal(response)
+	w.Header().Set("Content-type", "application/json")
+	w.Write(responseBytes)
+}
+
+func foo(ctx context.Context, ce cloudevents.Event) error {
+	vars := ofctx.VarsFromCtx(ctx)
+	response := map[string]string{
+		string(ce.Data()): vars["name"],
+	}
+	responseBytes, _ := json.Marshal(response)
+	klog.Infof("cloudevent - Data: %s", string(responseBytes))
+	return nil
+}
+
+func bar(ctx ofctx.Context, in []byte) (ofctx.Out, error) {
+	vars := ofctx.VarsFromCtx(ctx.GetNativeContext())
+	response := map[string]string{
+		string(in): vars["name"],
+	}
+	responseBytes, _ := json.Marshal(response)
+	return ctx.ReturnOnSuccess().WithData(responseBytes), nil
+}


### PR DESCRIPTION
Follow up of https://github.com/OpenFunction/functions-framework-go/pull/52#issuecomment-1165214944

before merging the PR:
1. ~~release ff-go and update the [version](https://github.com/OpenFunction/samples/compare/main...lizzzcai:add-example-path-parameters-go?expand=1#diff-9c879865fa9d13d3b9718589628b165349da6f04030b8546c3457c21376a3519R5) in this PR.~~
2. ~~update the default ff-go version in go-builder (optional, define the version in go.mod  should be enough)~~

To do: link the example to `openfunction.dev`

side topic:
I found that to enable dapr sidecar, user need to define the [outputs](https://github.com/OpenFunction/OpenFunction/blob/7e483d87dab622de7cf50f9a245e166719b906a2/pkg/core/serving/knative/servingrun.go#L277).  Here I use the annotation to enable manually. Can refine this part in the future.