### PR TITLE
update go samples

### DIFF
--- a/functions-framework/golang/Knative/http/go.mod
+++ b/functions-framework/golang/Knative/http/go.mod
@@ -1,9 +1,9 @@
 module main.go
 
-go 1.16
+go 1.17
 
 require (
-	github.com/OpenFunction/functions-framework-go v0.3.0
+	github.com/OpenFunction/functions-framework-go v0.4.0
 	github.com/fatih/structs v1.1.0
 	k8s.io/klog/v2 v2.30.0
 )

--- a/functions/knative/hello-world-go/README.md
+++ b/functions/knative/hello-world-go/README.md
@@ -11,7 +11,7 @@ You can refer to the [Installation Guide](https://github.com/OpenFunction/OpenFu
 Build the function locally
 
 ```sh
-pack build func-helloworld-go --builder openfunction/builder-go:v2.3.0-1.16 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true
+pack build func-helloworld-go --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true
 ```
 
 Run the function
@@ -68,8 +68,8 @@ You can create this secret by editing the ``REGISTRY_SERVER``, ``REGISTRY_USER``
     ```shell
    kubectl get functions.core.openfunction.io
    
-   NAME              BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         ADDRESS                                              AGE
-   function-sample   Succeeded    Running        builder-jgnzp   serving-q6wdp   http://function-sample.default.ofn.io/               22m
+   NAME              BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         ADDRESS                                                         AGE
+   function-sample   Succeeded    Running        builder-jgnzp   serving-q6wdp   http://function-sample.default.svc.cluster.local/               22m
     ```
 
    The `Function.status.addresses` field provides various methods for accessing functions.

--- a/functions/knative/hello-world-go/go.mod
+++ b/functions/knative/hello-world-go/go.mod
@@ -1,5 +1,5 @@
 module example.com/hello
 
-go 1.16
+go 1.17
 
-require github.com/OpenFunction/functions-framework-go v0.3.0
+require github.com/OpenFunction/functions-framework-go v0.4.0

--- a/functions/knative/hello-world-go/hello.go
+++ b/functions/knative/hello-world-go/hello.go
@@ -2,15 +2,18 @@ package hello
 
 import (
 	"fmt"
+	ofctx "github.com/OpenFunction/functions-framework-go/context"
 	"net/http"
 
 	"github.com/OpenFunction/functions-framework-go/functions"
 )
 
 func init() {
-	functions.HTTP("HelloWorld", HelloWorld)
+	functions.HTTP("HelloWorld", HelloWorld,
+		functions.WithFunctionPath("/{greeting}"))
 }
 
 func HelloWorld(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello, %s!\n", r.URL.Path[1:])
+	vars := ofctx.VarsFromCtx(r.Context())
+	fmt.Fprintf(w, "Hello, %s!\n", vars["greeting"])
 }

--- a/functions/knative/multiple-functions-go/README.md
+++ b/functions/knative/multiple-functions-go/README.md
@@ -11,7 +11,7 @@ You can refer to the [Installation Guide](https://github.com/OpenFunction/OpenFu
 Build the function locally
 
 ```sh
-pack build multiple-functions-go --builder openfunction/builder-go:v2.3.0-1.16 --env FUNC_NAME="MultipleFunctions"  --env FUNC_CLEAR_SOURCE=true
+pack build multiple-functions-go --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="MultipleFunctions"  --env FUNC_CLEAR_SOURCE=true
 ```
 
 Run the function
@@ -72,8 +72,8 @@ You can create this secret by editing the ``REGISTRY_SERVER``, ``REGISTRY_USER``
     ```shell
    kubectl get functions.core.openfunction.io
    
-   NAME              BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         URL                                              AGE
-   function-sample   Succeeded    Running        builder-jgnzp   serving-q6wdp   http://function-sample.default.ofn.io/   22m
+   NAME              BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         ADDRESS                                              AGE
+   function-sample   Succeeded    Running        builder-jgnzp   serving-q6wdp   http://function-sample.default.svc.cluster.local/    22m
     ```
    The `Function.status.addresses` field provides various methods for accessing functions.
    Get `Function` addresses by running following command:

--- a/functions/knative/multiple-functions-go/go.mod
+++ b/functions/knative/multiple-functions-go/go.mod
@@ -1,5 +1,5 @@
 module example.com/hello
 
-go 1.16
+go 1.17
 
-require github.com/OpenFunction/functions-framework-go v0.3.0
+require github.com/OpenFunction/functions-framework-go v0.4.0

--- a/functions/knative/with-output-binding/README.md
+++ b/functions/knative/with-output-binding/README.md
@@ -132,9 +132,9 @@ Check the current function status:
 ```shell
 kubectl get functions.core.openfunction.io
 
-NAME             BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         URL                                             AGE
-function-front   Succeeded    Running        builder-bhbtk   serving-vc6jw   http://function-front.default.ofn.io/           2m41s
-kafka-input      Succeeded    Running        builder-dprfd   serving-75vrt                                                   2m21s
+NAME             BUILDSTATE   SERVINGSTATE   BUILDER         SERVING         ADDRESS                                                   AGE
+function-front   Succeeded    Running        builder-bhbtk   serving-vc6jw   http://function-front.default.svc.cluster.local           2m41s
+kafka-input      Succeeded    Running        builder-dprfd   serving-75vrt                                                             2m21s
 ```
 
 The `Function.status.addresses` field provides various methods for accessing functions.

--- a/functions/knative/with-output-binding/go.mod
+++ b/functions/knative/with-output-binding/go.mod
@@ -1,8 +1,8 @@
 module example.com/bindings
 
-go 1.16
+go 1.17
 
 require (
-	github.com/OpenFunction/functions-framework-go v0.2.2
+	github.com/OpenFunction/functions-framework-go v0.4.0
 	github.com/fatih/structs v1.1.0
 )


### PR DESCRIPTION
Tested the following cases with ff-go v0.4.0 and builder-go:v2.4.0:
- sync-http 
- sync-openfunction
- sync-http-multipe-functions
- async-kafka-input
- async-cron-input-kafka-output

Signed-off-by: wrongerror <wangyifei@kubesphere.io>